### PR TITLE
修复一点点换行问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ This project is licensed under the GPLv3 License.
 
 This project uses SeaTable community edition, which is released under different licenses:
 
-dtable-web: Apache License v2
-dtable-events: Apache License v2
-dtable-server: Proprietary License
-seaf-server: AGPLv3
-thumbnail-server: Apache License v2
+- dtable-web: Apache License v2
+- dtable-events: Apache License v2
+- dtable-server: Proprietary License
+- seaf-server: AGPLv3
+- thumbnail-server: Apache License v2
 
 ## 常见问题解答
 （文档还在完善中，感谢你的查看）


### PR DESCRIPTION
修复了许可证列表的换行问题。（本来用两个换行符就能修复问题的，但我为了好看还是用了项目序号w）